### PR TITLE
added quotes to cron sched

### DIFF
--- a/dbt/models/churn_model_definition.sql
+++ b/dbt/models/churn_model_definition.sql
@@ -17,7 +17,7 @@
 					'metric' : 'roc_auc',
 					'excluded_model_types' : ['FastAI', 'KNN', 'NeuralNet', 'LightGBMLarge','NN_TORCH','NN_MXNET'],
 					'size' : 'large',
-					'schedule' : @daily
+					'schedule' : '@daily'
 				},
 				},
 

--- a/dbt/models/churn_model_definition.sql
+++ b/dbt/models/churn_model_definition.sql
@@ -17,7 +17,7 @@
 					'metric' : 'roc_auc',
 					'excluded_model_types' : ['FastAI', 'KNN', 'NeuralNet', 'LightGBMLarge','NN_TORCH','NN_MXNET'],
 					'size' : 'large',
-					'schedule' : '@daily'
+					'schedule' : "'@daily'"
 				},
 				},
 


### PR DESCRIPTION
Issue: https://github.com/continual-ai/customer-churn-example/issues/12

When executing `dbt run` with default churn_model_definition.sql
```
jinja2.exceptions.TemplateSyntaxError: unexpected char '@' at 569
  line 20
    'schedule' : @daily
```

Per https://github.com/continual-ai/customer-churn-example/commit/b01cd44cf39f058cd80a58d15d38c54b786165fe#diff-f8fd93c20656d666b05906bf6f9b7f7879a58418a90c54fd74fe58a9b9e5e95f

Should be:
```
'schedule' : '@daily'
```